### PR TITLE
Add onTabsChange callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,9 +158,16 @@ If true, the store will only synchronize once with the main tab. After that, the
 
 ##### options.onBecomeMain
 
-Type: `() => void`
+Type: `(id: number) => void`
 
 A callback that will be called when the tab becomes the main tab.
+
+##### options.onTabsChange
+
+Type: `(tabs: number[]) => void`
+
+A callback that will be called when the number of tabs changes.
+Only triggered on the main tab.
 
 ### useBroadcast (hooks)
 

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -13,7 +13,7 @@ const App = () => {
 			<div className="toast toast-top toast-start animate-in">
 				<div className="alert flex items-center justify-center">
 					<h1 className="font-semibold">use-broadcast-ts</h1>
-					<button className="btn btn-sm btn-neutral">v1.5.0</button>
+					<button className="btn btn-sm btn-neutral">v1.6.0</button>
 				</div>
 			</div>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "use-broadcast-ts",
-	"version": "1.5.0",
+	"version": "1.6.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "use-broadcast-ts",
-			"version": "1.5.0",
+			"version": "1.6.0",
 			"license": "MIT",
 			"devDependencies": {
 				"@babel/core": "7.21.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "use-broadcast-ts",
-	"version": "1.5.0",
+	"version": "1.6.0",
 	"description": "Use the Broadcast Channel API in React easily with hooks or Zustand, and Typescript!",
 	"type": "module",
 	"types": "./dist/index.d.ts",

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -22,8 +22,15 @@ export type SharedOptions = {
 
 	/**
 	 * Callback when this tab / window becomes the main tab / window
+	 * Triggered only in the main tab / window
 	 */
-	onBecomeMain?: () => void;
+	onBecomeMain?: (id: number) => void;
+
+	/**
+	 * Callback when a new tab is opened / closed
+	 * Triggered only in the main tab / window
+	 */
+	onTabsChange?: (ids: number[]) => void;
 };
 
 /**
@@ -196,6 +203,8 @@ const sharedImpl: SharedImpl = (f, options) => (set, get, store) => {
 			const new_id = tabs[tabs.length - 1]! + 1;
 			tabs.push(new_id);
 
+			options?.onTabsChange?.(tabs);
+
 			channel.postMessage({ action: 'add_new_tab', id: new_id } as Message);
 
 			return;
@@ -235,6 +244,8 @@ const sharedImpl: SharedImpl = (f, options) => (set, get, store) => {
 			const index = tabs.indexOf(e.data.id);
 			if (index !== -1) {
 				tabs.splice(index, 1);
+
+				options?.onTabsChange?.(tabs);
 			}
 		}
 
@@ -246,7 +257,7 @@ const sharedImpl: SharedImpl = (f, options) => (set, get, store) => {
 				isMain = true;
 				tabs.splice(0, tabs.length, ...e.data.tabs);
 
-				options?.onBecomeMain?.();
+				options?.onBecomeMain?.(id);
 			}
 		}
 	};
@@ -265,7 +276,7 @@ const sharedImpl: SharedImpl = (f, options) => (set, get, store) => {
 				isMain = true;
 				isSynced = true;
 
-				options?.onBecomeMain?.();
+				options?.onBecomeMain?.(id);
 			}
 		}, options?.mainTimeout ?? 100);
 	};


### PR DESCRIPTION
The `onTabsChange` callback can be used to listen the number of opened tabs.

```ts
onTabsChange: (ids) => console.log(`Got: ${ids.length} tabs`)
```

Note: It's only triggered on the "Main" tab.
Note 2: The `onBecomeMain` callback has now an `id` argument. You can retrieve the main tab id from it.